### PR TITLE
Discriminate between LimeSDR-USB and LimeSDR-Mini oversampling preferences

### DIFF
--- a/gpssim.c
+++ b/gpssim.c
@@ -1933,6 +1933,13 @@ void *gps_task(void *arg)
 		t0 = tmin;
 	}
 
+	printf("tmin = %4d/%02d/%02d,%02d:%02d:%02.0f (%d:%.0f)\n",
+		tmin.y, tmin.m, tmin.d, tmin.hh, tmin.mm, tmin.sec,
+		gmin.week, gmin.sec);
+	printf("tmax = %4d/%02d/%02d,%02d:%02d:%02.0f (%d:%.0f)\n",
+		tmax.y, tmax.m, tmax.d, tmax.hh, tmax.mm, tmax.sec,
+		gmax.week, gmax.sec);
+
 	printf("Start time = %4d/%02d/%02d,%02d:%02d:%02.0f (%d:%.0f)\n",
 		t0.y, t0.m, t0.d, t0.hh, t0.mm, t0.sec, g0.week, g0.sec);
 	printf("Duration = %.1f [sec]\n", ((double)numd)/10.0);

--- a/limegps.c
+++ b/limegps.c
@@ -383,6 +383,33 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
+	const lms_dev_info_t *devinfo =  LMS_GetDeviceInfo(device);
+
+	if (devinfo == NULL)
+	{
+		printf("ERROR: Failed to read device info: %s\n", LMS_GetLastErrorMessage());
+		goto out;
+	}
+
+    printf("deviceName: %s\n", devinfo->deviceName);
+    printf("expansionName: %s\n", devinfo->expansionName);
+    printf("firmwareVersion: %s\n", devinfo->firmwareVersion);
+    printf("hardwareVersion: %s\n", devinfo->hardwareVersion);
+    printf("protocolVersion: %s\n", devinfo->protocolVersion);
+    printf("gatewareVersion: %s\n", devinfo->gatewareVersion);
+    printf("gatewareTargetBoard: %s\n", devinfo->gatewareTargetBoard);
+
+    int limeOversample = 1;
+    if(strncmp(devinfo->deviceName, "LimeSDR-USB", 11) == 0)
+    {
+        limeOversample = 0;    // LimeSDR-USB works best with default oversampling
+        printf("Found a LimeSDR-USB\n");
+    }
+    else
+    {
+        printf("Found a LimeSDR-Mini\n");
+    }
+
 	int lmsReset = LMS_Reset(device);
 	if (lmsReset)
 	{
@@ -439,7 +466,8 @@ int main(int argc, char *argv[])
 	if (getSampleRateRange)
 		printf("Warning: Failed to get sample rate range: %s\n", LMS_GetLastErrorMessage());
 
-	int setSampleRate = LMS_SetSampleRate(device, (double)TX_SAMPLERATE, 1); // for LimeSDR mini
+	int setSampleRate = LMS_SetSampleRate(device, (double)TX_SAMPLERATE, limeOversample); 
+
 	if (setSampleRate)
 	{
 		printf("ERROR: Failed to set sample rate: %s\n", LMS_GetLastErrorMessage());


### PR DESCRIPTION
The LimeSDR-Mini oversampling setting does not seem to work on the LimeSDR-USB.  It causes the time increment to advance too slowly.  This code detects which LimeSDR is present and sets the oversampling accordingly.

Also included a start/end time display for the ephemeris data - useful for testing.