### PR TITLE
Add SV restrictions options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,16 @@ Options:
   -i               Interactive mode: North='w', South='s', East='d', West='a'
   -I               Disable ionospheric delay for spacecraft scenario
 ```
+### Restrictions optional
+
+If compiled with 'USE_RESTRICTIONS' defined, there are two more options:
+```
+  -R <elevation_min,azimuth_start,azimuth_start> Sky area restriction
+  -N <n_SV_max>      Maximum active SV restriction
+```
+Theses options allow to simulate not ideal receptions conditions:
+ - elevation_min:  Simulation of obstacles hiding the sky below a certain elevation
+ - azimuth_start,azimuth_start:  Simulation of obstacles hiding most of the sky, except the one between the minimum and maximum azimuth angle
 
 ### Build on Windows with Visual Studio
 

--- a/limegps.h
+++ b/limegps.h
@@ -46,6 +46,18 @@
 // Activate gamepad support
 //#define USE_GAMEPAD
 
+// Activate restriction support
+#define USE_RESTRICTIONS
+
+#ifdef USE_RESTRICTIONS
+typedef struct {
+	float elevation_mini_deg;
+	float azimuth_start_deg;
+	float azimuth_stop_deg;
+	int   max_enabled_SV;
+} restrictions_t;
+#endif /*USE_RESTRICTIONS*/
+
 typedef struct {
 	char navfile[MAX_CHAR];
 	char umfile[MAX_CHAR];
@@ -58,6 +70,9 @@ typedef struct {
 	int interactive;
 	int timeoverwrite;
 	int iono_enable;
+	#ifdef USE_RESTRICTIONS
+	restrictions_t restrictions;
+	#endif
 } option_t;
 
 typedef struct {
@@ -94,6 +109,7 @@ typedef struct {
 	pthread_cond_t fifo_write_ready;
 
 	double time;
+
 } sim_t;
 
 extern void *gps_task(void *arg);


### PR DESCRIPTION
Theses options allow to simulate not ideal receptions conditions:
 - elevation_min:  Simulation of obstacles hiding the sky below a certain elevation
 - azimuth_start,azimuth_start:  Simulation of obstacles hiding most of the sky, except the one between the minimum and maximum azimuth angle